### PR TITLE
Fix digest hashing bug and add instructions

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -22,7 +22,7 @@ function login(email, password) {
     const [id, em, name, role, managerId, lang, salt, hash] = rows[i];
     if (em === email) {
       const sha = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, salt + password);
-      const hashStr = sha.map(function(b){return ('0' + (b & 0xFF).toString(16)).slice(-2);}).join('');
+      const hashStr = Array.from(sha, b => ('0' + (b & 0xFF).toString(16)).slice(-2)).join('');
       if (hashStr === hash) {
         const cache = CacheService.getUserCache();
         cache.put(CACHE_KEY, JSON.stringify({id:id, email:em, name:name, role:role, managerId:managerId, lang:lang}), SESSION_DURATION);
@@ -191,7 +191,7 @@ function addUser(user) {
   const sheet = ss.getSheetByName(USERS_SHEET);
   const salt = Utilities.getUuid();
   const sha = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, salt + user.password);
-  const hash = sha.map(function(b){return ('0' + (b & 0xFF).toString(16)).slice(-2);}).join('');
+  const hash = Array.from(sha, b => ('0' + (b & 0xFF).toString(16)).slice(-2)).join('');
   const id = new Date().getTime();
   sheet.appendRow([id, user.email, user.name, user.role, user.managerId||'', user.lang||'en', salt, hash]);
 }

--- a/index.html
+++ b/index.html
@@ -62,6 +62,8 @@ document.addEventListener('DOMContentLoaded',init);
 <button id="langBtn" onclick="saveLang()">EN</button>
 </nav>
 <section id="home" class="hidden">
+<h2>Welcome to the Employee Review Portal</h2>
+<p>Select an option from the navigation bar to view your reviews or schedule a meeting. Use the language button to switch between English and Spanish.</p>
 <div id="reviews"></div>
 </section>
 <section id="schedule" class="hidden">


### PR DESCRIPTION
## Summary
- handle Apps Script byte arrays when computing password hashes
- add a quick introduction for navigating the review page

## Testing
- `node -e "require('fs').readFile('Code.gs','utf8', (err,data)=>{if(err)throw err; try{new Function(data); console.log('OK');}catch(e){console.error('ERROR', e.message);} });"`

------
https://chatgpt.com/codex/tasks/task_e_687cff57c60c832289208a7dc16aee9f