### PR TITLE
Fix question loading fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,10 +114,22 @@ function renderReviews(){const c=document.getElementById('reviewsList');if(!c)re
 
 let questions=[];
 function loadQuestions(){
-  google.script.run.withSuccessHandler(q=>{
-    questions=(q&&q.length)?q:defaultQuestions;
+  if(typeof google==='undefined'||!google.script||!google.script.run){
+    questions=defaultQuestions;
     renderQuestionList();
-  }).getQuestions();
+    return;
+  }
+  google.script.run
+    .withSuccessHandler(q=>{
+      questions=(q&&q.length)?q:defaultQuestions;
+      renderQuestionList();
+    })
+    .withFailureHandler(err=>{
+      console.error('loadQuestions failed',err);
+      questions=defaultQuestions;
+      renderQuestionList();
+    })
+    .getQuestions();
 }
 function renderQuestionList(){
   const qd=document.getElementById('questionList');


### PR DESCRIPTION
## Summary
- ensure the question list renders even if Google script calls fail

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d08350e2c8322ae5c1b723b98bb95