### PR TITLE
Simpler dev panel access

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This project contains a simple Google Apps Script web application used to collec
 - HTML/JavaScript frontend (`index.html`) displays the review form and includes a small EN/ES switch to change languages. All visible text uses `data-i18n-key` attributes so the entire interface switches language.
 - Review questions can be loaded from a spreadsheet or fall back to defaults in the page.
 - Managers and HR can adjust compensation and record final expectations.
-- Authorized developers can create new users from the dev panel with securely hashed passwords.
+- The dev button is always visible, but opening the dev panel requires
+  authentication through the Chrome browser OAuth session. Only the accounts
+  `skhun@dublincleaners.com` and `ss.sku@protonmail.com` are allowed to access
+  it. Authorized developers can create new users from the panel with securely
+  hashed passwords.
 
 The project is intentionally lightweight and open. Feel free to modify or extend it as needed.

--- a/index.html
+++ b/index.html
@@ -183,16 +183,9 @@ function renderReviews(){const c=document.getElementById('reviewsList');if(!c)re
 
 function showDevButton(){
   const btn=document.getElementById('devBtn');
-  if(!btn||!google||!google.script||!google.script.run)return;
-  google.script.run.withSuccessHandler(isDev=>{
-    if(isDev){
-      btn.classList.remove('hidden');
-      btn.disabled=false;
-    }else{
-      btn.classList.add('hidden');
-      btn.disabled=true;
-    }
-  }).isAuthorizedDev();
+  if(!btn)return;
+  btn.classList.remove('hidden');
+  btn.disabled=false;
 }
 
 function openDevPanel(){
@@ -335,7 +328,7 @@ document.addEventListener('DOMContentLoaded',init);
   <span>ES</span>
 </div>
 <button id="navLoginBtn" onclick="navLogin()">Login</button>
-<button id="devBtn" class="hidden" onclick="openDevPanel()">Dev</button>
+<button id="devBtn" onclick="openDevPanel()">Dev</button>
 </nav>
 <div id="loadingBar" class="loading-bar hidden"><span></span></div>
 <section id="home" class="hidden">


### PR DESCRIPTION
## Summary
- always render the dev button
- simplify `showDevButton` logic
- document OAuth-based dev panel access

## Testing
- `node - <<'EOF'
const fs=require('fs');
new Function(fs.readFileSync('Code.gs','utf8'));
console.log('Syntax OK');
EOF`
- `xmllint --html --noout index.html` *(fails: Unexpected end tag)*
- `sudo apt-get install -y libxml2-utils`

------
https://chatgpt.com/codex/tasks/task_e_687d4a8aa02c8322a335d86c4c2aa91a