### PR TITLE
Fix review reset and remove autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This project contains a simple Google Apps Script web application used to collec
 - HTML/JavaScript frontend (`index.html`) displays the review form and includes a small EN/ES switch to change languages. All visible text uses `data-i18n-key` attributes so the entire interface switches language.
 - Review questions can be loaded from a spreadsheet or fall back to defaults in the page.
 - Managers and HR can adjust compensation and record final expectations.
-- Review answers are now automatically saved as you type, so progress persists across logins.
 - Submission status is displayed next to the review button for quick feedback.
 - The dev button is always visible, but opening the dev panel requires
   authentication through the Chrome browser OAuth session. Only the accounts

--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@ let user=null,config={},lang=localStorage.getItem('lang')||'en';
 let loadingReviews=false;
 let pendingSection=null;
 let currentReviewId=null;
-let autoSaveTimeout=null;
 let selectedYear=new Date().getFullYear();
 
 const defaultQuestions=[
@@ -144,7 +143,6 @@ function init(){
   applyTranslations();
   loadQuestions();
   const revSection=document.getElementById('reviews');
-  if(revSection) revSection.addEventListener('input',scheduleAutoSave);
   google.script.run.withSuccessHandler(c=>{config=c;loadSession();}).loadConfig();
 }
 function loadSession(){
@@ -200,7 +198,6 @@ function login(){
 function navLogin(){
   const loginDiv=document.getElementById('login');
   if(user){
-    saveDraftReview();
     google.script.run.logout();
     user=null;
     loginDiv.classList.add('hidden');
@@ -260,8 +257,7 @@ function updateReviewMenu(){
 
 function selectReviewYear(y){
   selectedYear=y;
-  fillSavedAnswers();
-loadReviews();
+  loadReviews();
   const menu=document.getElementById('reviewMenu');
   if(menu) menu.classList.remove('show');
 }
@@ -421,24 +417,10 @@ function gatherAnswers(){
   });
   return ans;
 }
-function saveDraftReview(){
-  if(!user) return;
-  const ans=gatherAnswers();
-  const review={id:currentReviewId,employeeId:user.id,type:'SELF',data:{year:selectedYear,answers:ans},status:'DRAFT'};
-  google.script.run.withSuccessHandler(r=>{
-    currentReviewId=r.id;
-    const exp={result:document.querySelector('input[name=finalExp]:checked')?.value||'',notes:document.getElementById('finalNotes').value,empSign:{name:document.getElementById('empSign').value,ts:new Date().toISOString()},mgrSign:{name:document.getElementById('mgrSign').value,ts:new Date().toISOString()}};
-    google.script.run.saveFinalExpectation(r.id,exp);
-    loadReviews();
-  }).saveReview(review);
-}
-function scheduleAutoSave(){
-  clearTimeout(autoSaveTimeout);
-  autoSaveTimeout=setTimeout(saveDraftReview,1000);
-}
 function submitReview(){
   const ans=gatherAnswers();
   const review={id:currentReviewId,employeeId:user.id,type:'SELF',data:{year:selectedYear,answers:ans}};
+  document.body.style.cursor='wait';
   google.script.run.withSuccessHandler(r=>{
     currentReviewId=r.id;
     const adjBlock=document.getElementById('compAdjust');
@@ -450,9 +432,11 @@ function submitReview(){
     google.script.run.saveFinalExpectation(r.id,exp);
     loadReviews();
     document.getElementById('submitMsg').textContent=t('reviewSaved');
+    document.body.style.cursor='';
   })
   .withFailureHandler(err=>{
     document.getElementById('submitMsg').textContent=err.message||t('saveFailed');
+    document.body.style.cursor='';
   })
   .saveReview(review);
 }


### PR DESCRIPTION
## Summary
- remove autosave mention from README
- stop attaching input handler that saved drafts automatically
- drop the draft saving code
- when selecting a review year just reload reviews so last saved values fill in
- show an hourglass cursor while saving reviews

## Testing
- `node -e "require('fs').readFileSync('index.html','utf8')"`

------
https://chatgpt.com/codex/tasks/task_e_687d66c81c148322814694de48ceb42c