### PR TITLE
Fix review year selection loading

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -145,6 +145,24 @@ function listReviews() {
   return res;
 }
 
+/** Get a specific year's self review for the session user */
+function getReviewByYear(year){
+  const user = getSession();
+  if(!user) throw new Error("not auth");
+  const ss = getSpreadsheet();
+  const sheet = ss.getSheetByName(REVIEWS_SHEET);
+  if(!sheet) return null;
+  const rows = sheet.getDataRange().getValues();
+  for(let i=1;i<rows.length;i++){
+    const [id, empId, type, dataStr, status, ts] = rows[i];
+    if(empId == user.id && type === "SELF"){
+      const data = JSON.parse(dataStr || "{}");
+      if(Number(data.year) === Number(year)) return {id:id, employeeId:empId, type:type, data:data, status:status, ts:ts};
+    }
+  }
+  return null;
+}
+
 /** Helper to get direct reports */
 function getDirectReports(managerId) {
   const ss = getSpreadsheet();

--- a/index.html
+++ b/index.html
@@ -258,7 +258,18 @@ function updateReviewMenu(){
 
 function selectReviewYear(y){
   selectedYear=y;
-  loadReviews();
+  if(typeof google==='undefined'||!google.script||!google.script.run){
+    fillSavedAnswers();
+  }else{
+    google.script.run.withSuccessHandler(rv=>{
+      if(rv){
+        reviews=reviews.filter(r=>!(r.type==='SELF'&&r.employeeId==user.id&&Number(r.data.year)==Number(y)));
+        reviews.push(rv);
+      }
+      fillSavedAnswers();
+      updateReviewMenu();
+    }).getReviewByYear(y);
+  }
   const menu=document.getElementById('reviewMenu');
   if(menu) menu.classList.remove('show');
 }


### PR DESCRIPTION
## Summary
- allow fetching a single review for a specific year
- load saved answers when selecting a year using new API

## Testing
- `node -e "require('fs').readFileSync('index.html'); console.log('ok');" && echo 'HTML loaded'`

------
https://chatgpt.com/codex/tasks/task_e_687d6a4983188322989c32efd918e2f9