### PR TITLE
Store review data in Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project contains a simple Google Apps Script web application used to collect annual employee reviews.
 
 ## Features
-- Google Apps Script backend (`Code.gs`) manages user authentication, review data, and language preference storage. User passwords are stored as salted SHA-256 hashes.
+- Google Apps Script backend (`Code.gs`) manages user authentication, review data, and language preference storage. Review submissions are stored as JSON files in a private Drive folder instead of a spreadsheet, and user passwords are stored as salted SHA-256 hashes.
 - HTML/JavaScript frontend (`index.html`) displays the review form and includes a small EN/ES switch to change languages. All visible text uses `data-i18n-key` attributes so the entire interface switches language.
 - Review questions can be loaded from a spreadsheet or fall back to defaults in the page.
 - Managers and HR can adjust compensation and record final expectations.


### PR DESCRIPTION
## Summary
- add Drive-based storage for review data via helper functions
- update review-related functions to use Drive storage
- refresh dashboard, CSV export, and notifications to read from Drive
- update final expectation save logic for Drive
- note Drive storage in README

## Testing
- `node --check Code.gs`
- `tidy -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_687d78572c9483228c7650d1ae2e38cd