### PR TITLE
Fix config header parse

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -144,7 +144,11 @@ function loadConfig() {
   const sheet = ss.getSheetByName(CONFIG_SHEET);
   const rows = sheet.getDataRange().getValues();
   const cfg = {};
-  rows.forEach(r => { cfg[r[0]] = {en:r[1], es:r[2]}; });
+  rows.forEach((r,i) => {
+    if(i === 0) return; // skip header row
+    if(!r[0]) return;
+    cfg[r[0]] = {en:r[1], es:r[2]};
+  });
   return cfg;
 }
 


### PR DESCRIPTION
## Summary
- skip CONFIG sheet header row when building translations

## Testing
- `node -e "new Function(require('fs').readFileSync('Code.gs','utf8'))"`
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_687d84601114832294c2a3087b0df777