### PR TITLE
Fix JS environment checks and add user password hashing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -292,7 +292,8 @@ function addUser(user) {
   const ss = getSpreadsheet();
   const sheet = ss.getSheetByName(USERS_SHEET);
   const id = new Date().getTime();
-  sheet.appendRow([id, user.userId, user.name, user.role, user.managerId||'', user.lang||'en']);
+  const h = createHash(user.password || DEV_PASSWORD);
+  sheet.appendRow([id, user.userId, user.name, user.role, user.managerId||'', user.lang||'en', h.hashHex, h.saltHex, new Date()]);
 }
 
 /** Check if session user is in DEV_USERS */

--- a/index.html
+++ b/index.html
@@ -202,7 +202,10 @@ function login(){
 function navLogin(){
   const loginDiv=document.getElementById('login');
   if(user){
-    google.script.run.logout();
+    if(typeof google!==
+      'undefined' && google.script && google.script.run){
+      google.script.run.logout();
+    }
     user=null;
     reviews=[];
     loginDiv.classList.add('hidden');
@@ -216,7 +219,9 @@ function navLogin(){
 function toggleLang(){
   lang=document.getElementById('langToggle').checked?'es':'en';
   if(user) user.lang=lang;
-  if(google&&google.script&&google.script.run)google.script.run.saveLang(lang);
+  if(typeof google!=='undefined' && google.script && google.script.run){
+    google.script.run.saveLang(lang);
+  }
   localStorage.setItem('lang',lang);
   applyTranslations();
   renderReviews();
@@ -232,7 +237,7 @@ function loadReviews(){
 }
 
 function loadSavedReview(){
-  if(!user || !google || !google.script || !google.script.run) return;
+  if(!user || typeof google==='undefined' || !google.script || !google.script.run) return;
   google.script.run.withSuccessHandler(r=>{
     if(r){
       // replace existing saved review for selected year
@@ -252,7 +257,7 @@ function showDevButton(){
 }
 
 function openDevPanel(){
-  if(!google||!google.script||!google.script.run)return;
+  if(typeof google==='undefined' || !google.script || !google.script.run) return;
   google.script.run.withSuccessHandler(isDev=>{
     if(isDev){
       document.querySelectorAll('section').forEach(s=>s.classList.add('hidden'));


### PR DESCRIPTION
## Summary
- avoid `ReferenceError` when the Google Apps Script object isn't available
- hash password when using the older `addUser` API

## Testing
- `htmlhint index.html`
- `jshint index.html`


------
https://chatgpt.com/codex/tasks/task_e_687d8580bd3483229dc471be823c1277