### PR TITLE
Fix home page data leak

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,6 @@ function loadSession(){
       localStorage.setItem('lang',lang);
       applyTranslations();
       showDevButton();
-      loadReviews();
       show('home');
     }else{
       applyTranslations();
@@ -591,7 +590,6 @@ document.addEventListener('DOMContentLoaded',init);
 <section id="home" class="hidden">
 <h2 data-i18n-key="welcomeTitle">Welcome to the Employee Review Portal</h2>
 <p data-i18n-key="welcomeMsg">Select an option from the navigation bar to view your reviews or schedule a meeting. Use the language button to switch between English and Spanish.</p>
-<div id="reviewsList"></div>
 </section>
 <section id="reviews" class="hidden">
 <form id="reviewForm" onsubmit="submitReview();return false;">


### PR DESCRIPTION
## Summary
- remove `loadReviews()` call from initial session load so saved reviews aren't automatically rendered
- delete leftover `reviewsList` container that showed user data on the home page

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('index.html','utf8');const m=html.match(/<script>([\s\S]*?)<\/script>/);if(m){try{new Function(m[1]);console.log('JS OK');}catch(e){console.error('JS Error:',e.message);}}else{console.error('No script');}"`


------
https://chatgpt.com/codex/tasks/task_e_687ed0afd9f0832295c45dafe20d1c89