### PR TITLE
Prevent login and admin overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,6 +323,9 @@ function navLogin(){
     show('home');
   }else{
     loginDiv.classList.toggle('hidden');
+    // hide dev panel when showing login
+    const dev=document.getElementById('devPanel');
+    if(dev)dev.classList.add('hidden');
   }
 }
 
@@ -371,6 +374,9 @@ function openDevPanel(){
   google.script.run.withSuccessHandler(isDev=>{
     if(isDev){
       document.querySelectorAll('body>section').forEach(s=>s.classList.add('hidden'));
+      // hide login form if visible
+      const loginDiv=document.getElementById('login');
+      if(loginDiv) loginDiv.classList.add('hidden');
       document.getElementById('devPanel').classList.remove('hidden');
     }else{
       alert('Not authorized');


### PR DESCRIPTION
## Summary
- hide the admin panel when user login form is opened
- hide the login form when the dev panel is displayed

## Testing
- `htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_687ee3a420f083228a303f05183bbe00