### PR TITLE
Fix calendar rendering after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,13 +607,14 @@ function addNewUser(){
 let calendar,startSel,endSel;
 async function initCalendar(){
   const el=document.getElementById('calendar');
-  if(!el||calendar) return;
-  calendar=new FullCalendar.Calendar(el,{
-    initialView:'timeGridWeek',
-    headerToolbar:false,
-    allDaySlot:false,
-    selectable:true,
-    slotDuration:'00:30',
+  if(!el) return;
+  if(!calendar){
+    calendar=new FullCalendar.Calendar(el,{
+      initialView:'timeGridWeek',
+      headerToolbar:false,
+      allDaySlot:false,
+      selectable:true,
+      slotDuration:'00:30',
     slotMinTime:'07:00',
     slotMaxTime:'19:00',
     locale:lang==='es'?'es':'en',
@@ -623,8 +624,10 @@ async function initCalendar(){
     },
     select:(info)=>openDialog(info.start,info.end),
     dateClick:(info)=>openDialog(info.date,new Date(info.date.getTime()+30*60*1000))
-  });
+    });
+  }
   calendar.render();
+  calendar.refetchEvents();
 }
 function openDialog(start,end){
   startSel=start;endSel=end;


### PR DESCRIPTION
## Summary
- render the booking calendar whenever the Schedule page is shown
- refresh events after rendering so authenticated data loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f8123349c8322ae3abe5a011b772c