### PR TITLE
Add manager comments box to review questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,20 +71,20 @@ const defaultQuestions=[
   {id:'attendance',en:'Attendance & Punctuality',es:'Asistencia y Puntualidad',extras:[
     {id:'absences',label:'Absences without notice (days)',label_es:'Ausencias sin aviso (días)',type:'number'},
     {id:'late',label:'Late arrivals (days)',label_es:'Llegadas tarde (días)',type:'number'},
-    {id:'comments',label:'Comments',label_es:'Comentarios',type:'textarea'}]},
-  {id:'performance',en:'Performance Improvements: What did you do more, better, or more efficiently last year, up till now?',es:'Mejoras de rendimiento',extra:'textarea'},
-  {id:'values',en:'Living Our Core Values: How have you embodied our core values? Provide specific examples.',es:'Vivir nuestros valores',extra:'textarea'},
-  {id:'growth',en:'Personal Growth: How did you improve your knowledge or skills last year, up till now?',es:'Crecimiento personal',extra:'textarea'},
-  {id:'learning',en:'Learning New Skills: Did you take or create opportunities to learn a new skill or enhance an existing one?',es:'Aprendizaje de nuevas habilidades',extra:'textarea'},
-  {id:'team',en:'Team Support: How did you support your teammates in developing their skills?',es:'Apoyo al equipo',extra:'textarea'},
-  {id:'flexibility',en:'Flexibility: When asked to cover for others, did you agree? Share an example.',es:'Flexibilidad',extra:'textarea'},
-  {id:'initiative',en:'Initiative: Describe a time you proactively improved a process or solved a problem without being asked.',es:'Iniciativa',extra:'textarea'},
-  {id:'proactive',en:'Proactive Contributions: How did you proactively use downtime to tackle additional tasks?',es:'Contribuciones proactivas',extra:'textarea'},
-  {id:'innovation',en:'Innovation & Process Improvement: Have you suggested or implemented improvements to our processes, services, or workplace? Describe your idea and its impact.',es:'Innovaci\u00f3n y mejora de procesos',extra:'textarea'},
+    {id:'employeeComments',label:"Employee's Comments",label_es:'Comentarios del empleado',type:'textarea'}]},
+  {id:'performance',en:'Performance Improvements: What did you do more, better, or more efficiently last year, up till now?',es:'Mejoras de rendimiento',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'values',en:'Living Our Core Values: How have you embodied our core values? Provide specific examples.',es:'Vivir nuestros valores',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'growth',en:'Personal Growth: How did you improve your knowledge or skills last year, up till now?',es:'Crecimiento personal',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'learning',en:'Learning New Skills: Did you take or create opportunities to learn a new skill or enhance an existing one?',es:'Aprendizaje de nuevas habilidades',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'team',en:'Team Support: How did you support your teammates in developing their skills?',es:'Apoyo al equipo',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'flexibility',en:'Flexibility: When asked to cover for others, did you agree? Share an example.',es:'Flexibilidad',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'initiative',en:'Initiative: Describe a time you proactively improved a process or solved a problem without being asked.',es:'Iniciativa',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'proactive',en:'Proactive Contributions: How did you proactively use downtime to tackle additional tasks?',es:'Contribuciones proactivas',extras:[{id:'employeeComments',type:'textarea'}]},
+  {id:'innovation',en:'Innovation & Process Improvement: Have you suggested or implemented improvements to our processes, services, or workplace? Describe your idea and its impact.',es:'Innovaci\u00f3n y mejora de procesos',extras:[{id:'employeeComments',type:'textarea'}]},
   {id:'crossshadow',en:'Cross Shadowing Program Participation',es:'Programa Cross Shadowing',rating:false,extras:[
     {id:'participation',label:'Did you participate? (Yes/No/Partial)',label_es:'¿Participaste? (Sí/No/Parcial)',type:'select',options:['Yes','No','Partial']},
-    {id:'comments',label:'Comments',label_es:'Comentarios',type:'textarea'}]},
-  {id:'future',en:'Future Interests: Is there another role or skill you\u2019d like to explore in the future?',es:'Intereses futuros',rating:false,extra:'textarea'}
+    {id:'employeeComments',label:"Employee's Comments",label_es:'Comentarios del empleado',type:'textarea'}]},
+  {id:'future',en:'Future Interests: Is there another role or skill you\u2019d like to explore in the future?',es:'Intereses futuros',rating:false,extras:[{id:'employeeComments',type:'textarea'}]}
 ];
 const translations={
   en:{
@@ -98,6 +98,7 @@ const translations={
     finalExpTitle:'Final Performance Expectation',belowExp:'Below Expectations',meetsExp:'Meets Expectations',exceedsExp:'Exceeds Expectations',
     below:'Below',meets:'Meets',exceeds:'Exceeds',
     notesPlaceholder:'Notes',contactQuestions:'Contact Sea Khun with questions.',empSignature:'Employee Signature',mgrSignature:'Manager Signature',submitReview:'Submit Review',
+    employeeComments:"Employee's Comments",managerComments:"Manager's Comments",
     reviewSaved:'Review saved',saveFailed:'Failed to save review',saving:'Saving...',
     scheduleBtn:'Schedule Review Meeting',
     bookPrompt:'Book this time?',
@@ -162,6 +163,7 @@ const translations={
     finalExpTitle:'Expectativa de desempeño final',belowExp:'Debajo de las expectativas',meetsExp:'Cumple con las expectativas',exceedsExp:'Supera las expectativas',
     below:'Debajo',meets:'Cumple',exceeds:'Supera',
     notesPlaceholder:'Notas',contactQuestions:'Contacte a Sea Khun con preguntas.',empSignature:'Firma del empleado',mgrSignature:'Firma del gerente',submitReview:'Enviar revisión',
+    employeeComments:'Comentarios del empleado',managerComments:'Comentarios del gerente',
     reviewSaved:'Revisión guardada',saveFailed:'No se pudo guardar la revisión',saving:'Guardando...',
     scheduleBtn:'Agendar Reunión de Revisión',
     bookPrompt:'¿Reservar esta hora?',
@@ -447,7 +449,8 @@ function renderQuestionList(){
     }
     if(Array.isArray(q.extras)){
       q.extras.forEach(ex=>{
-        const lbl=ex['label_'+lang]||ex.label;
+        let lbl=ex['label_'+lang]||ex.label;
+        if(ex.type==='textarea' && ex.id!=='managerComments') lbl=t('employeeComments');
         html+='<label>'+lbl;
         if(ex.type==='textarea')html+='<textarea class="extra" data-sub="'+ex.id+'"></textarea>';
         else if(ex.type==='select'){
@@ -458,10 +461,11 @@ function renderQuestionList(){
         html+='</label>';
       });
     }else if(q.extra==='textarea'){
-      html+='<textarea class="extra"></textarea>';
+      html+='<label>'+t('employeeComments')+'<textarea class="extra" data-sub="employeeComments"></textarea></label>';
     }else if(q.extra==='number'){
       html+='<input type="number" class="extra">';
     }
+    html+='<label>'+t('managerComments')+'<textarea class="extra" data-sub="managerComments"></textarea></label>';
     div.innerHTML=html;
     qd.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- add Employee and Manager comment fields to question list
- localize new comment labels

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_687f88ab9fa083229c40b19f628a1ef6