### PR TITLE
Enable OAuth auto-login for devs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -141,6 +141,12 @@ function getSession() {
         return user;
       }
     }
+    // allow devs without sheet entry to auto-login via OAuth
+    if (DEV_USERS.indexOf(email) !== -1) {
+      const user = {id:email, userId:email, name:email, role:'DEV', managerId:'', lang:'en'};
+      cache.put(CACHE_KEY, JSON.stringify(user), SESSION_DURATION);
+      return user;
+    }
   }
   return null;
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project contains a simple Google Apps Script web application used to collec
   authentication through the Chrome browser OAuth session. Only the accounts
   `skhun@dublincleaners.com` and `ss.sku@protonmail.com` are allowed to access
   it. Authorized developers can create new users from the panel with securely
-  hashed passwords.
+  hashed passwords. Developer accounts automatically sign in via the Chrome
+  browser's OAuth session and do not require a password.
 
 The project is intentionally lightweight and open. Feel free to modify or extend it as needed.


### PR DESCRIPTION
## Summary
- allow developers to automatically authenticate using OAuth without passwords
- clarify README that dev accounts sign in via OAuth

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68810193d4f08322bab6e6fd72f53212