### PR TITLE
Auto login dev panel via OAuth

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -329,7 +329,17 @@ function addUser(user) {
 /** Check if session user is in DEV_USERS */
 function isAuthorizedDev() {
   const email = Session.getActiveUser().getEmail();
-  return DEV_USERS.indexOf(email) !== -1;
+  const ok = DEV_USERS.indexOf(email) !== -1;
+  if (ok) {
+    // ensure a cached DEV session so other calls recognize the user
+    const cache = CacheService.getUserCache();
+    if (!cache.get(CACHE_KEY)) {
+      const user = {id: email, userId: email, name: email,
+                    role: 'DEV', managerId: '', lang: 'en'};
+      cache.put(CACHE_KEY, JSON.stringify(user), SESSION_DURATION);
+    }
+  }
+  return ok;
 }
 
 /** Admin panel API to add simple user entry */

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project contains a simple Google Apps Script web application used to collec
   `skhun@dublincleaners.com` and `ss.sku@protonmail.com` are allowed to access
   it. Authorized developers can create new users from the panel with securely
   hashed passwords. Developer accounts automatically sign in via the Chrome
-  browser's OAuth session and do not require a password.
+  browser's OAuth session and do not require a password. Opening the dev
+  panel now establishes a dev session automatically when a verified account
+  is detected.
 
 The project is intentionally lightweight and open. Feel free to modify or extend it as needed.

--- a/index.html
+++ b/index.html
@@ -421,6 +421,8 @@ function openDevPanel(){
   if(!navigator.userAgent.includes('Chrome')){alert('Use Chrome browser');return;}
   google.script.run.withSuccessHandler(isDev=>{
     if(isDev){
+      // fetch session after authorization so client knows user role
+      google.script.run.withSuccessHandler(u=>{if(u)user=u;}).getSession();
       document.querySelectorAll('body>section').forEach(s=>s.classList.add('hidden'));
       const loginDiv=document.getElementById('login');
       if(loginDiv)loginDiv.classList.add('hidden');


### PR DESCRIPTION
## Summary
- create a dev session when `isAuthorizedDev` runs
- fetch user session when opening the dev panel
- note the auto dev session behaviour in `README`

## Testing
- `npm install -g jshint`
- `jshint Code.gs index.html` *(fails: many warnings because ES6 and HTML)*

------
https://chatgpt.com/codex/tasks/task_e_6881040d59a083228d10dd9adea81035