### PR TITLE
Fix dev auto-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This project contains a simple Google Apps Script web application used to collec
   `skhun@dublincleaners.com` and `ss.sku@protonmail.com` are allowed to access
   it. Authorized developers can create new users from the panel with securely
   hashed passwords. Developer accounts automatically sign in via the Chrome
-  browser's OAuth session and do not require a password. Opening the dev
-  panel now establishes a dev session automatically when a verified account
-  is detected.
+  browser's OAuth session and do not require a password. When the page loads and
+  the OAuth email matches one of the developer accounts, the dev panel opens
+  automatically with no password prompt.
 
 The project is intentionally lightweight and open. Feel free to modify or extend it as needed.

--- a/index.html
+++ b/index.html
@@ -312,7 +312,12 @@ function loadSession(){
       localStorage.setItem('lang',lang);
       applyTranslations();
       showDevButton();
-      show('home');
+      document.getElementById('navLoginBtn').textContent=t('logout');
+      if(user.role==='DEV'){
+        openDevPanel();
+      }else{
+        show('home');
+      }
     }else{
       applyTranslations();
       showDevButton();


### PR DESCRIPTION
## Summary
- autoload dev panel when OAuth session belongs to a dev account
- clarify README dev login details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688106470cfc8322993173ba278cc941