### PR TITLE
Add password reset and remove complexity check

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -400,6 +400,23 @@ function updateUserRole(userID, role){
   throw new Error('user_not_found');
 }
 
+/** Reset a user's password */
+function updateUserPassword(userID, newPwd){
+  if(!isAuthorizedDev()) throw new Error('denied');
+  const sheet = SpreadsheetApp.openById(ADMIN_SHEET_ID).getSheetByName(USERS_SHEET);
+  const data = sheet.getDataRange().getValues();
+  for(let i=1;i<data.length;i++){
+    if(data[i][1]==userID){
+      const h=createHash(newPwd);
+      sheet.getRange(i+1,7).setValue(h.hashHex);
+      sheet.getRange(i+1,8).setValue(h.saltHex);
+      logDevAction(Session.getActiveUser().getEmail(),'reset password',userID);
+      return true;
+    }
+  }
+  throw new Error('user_not_found');
+}
+
 
 /** Log developer actions */
 function logDevAction(devEmail, action, userId){

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ This project contains a simple Google Apps Script web application used to collec
 - The dev button is always visible, but opening the dev panel requires
   authentication through the Chrome browser OAuth session. Only the accounts
   `skhun@dublincleaners.com` and `ss.sku@protonmail.com` are allowed to access
-  it. Authorized developers can create new users from the panel with securely
-  hashed passwords. Developer accounts automatically sign in via the Chrome
-  browser's OAuth session and do not require a password. When the page loads and
-  the OAuth email matches one of the developer accounts, the dev panel opens
-  automatically with no password prompt.
+  it. Authorized developers can create new users from the panel with passwords of
+  any complexity. They can also reset an existing user's password from the dev
+  panel. All passwords are hashed before being stored. Developer accounts
+  automatically sign in via the Chrome browser's OAuth session and do not
+  require a password. When the page loads and the OAuth email matches one of the
+  developer accounts, the dev panel opens automatically with no password prompt.
 
 The project is intentionally lightweight and open. Feel free to modify or extend it as needed.

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@ let loadingReviews=false;
 let pendingSection=null;
 let currentReviewId=null;
 let selectedYear=new Date().getFullYear();
+let resetUid=null;
 
 const defaultQuestions=[
   {id:'attendance',en:'Attendance & Punctuality',es:'Asistencia y Puntualidad',extras:[
@@ -687,11 +688,13 @@ function renderUserTable(list){
       `<td><select class="roleSel" disabled><option>Employee</option><option>Manager</option><option>Admin</option></select></td>`+
       `<td class="actions"><button class="editBtn" title="Edit">✏️</button>`+
       `<button class="saveBtn hidden" title="Save">💾</button>`+
-      `<button class="cancelBtn hidden" title="Cancel">✖</button></td>`;
+      `<button class="cancelBtn hidden" title="Cancel">✖</button>`+
+      `<button class="pwBtn" title="Reset Password">🔑</button></td>`;
     tr.querySelector('.roleSel').value=u.role;
     tr.querySelector('.editBtn').onclick=()=>enableEdit(tr,u.userId);
     tr.querySelector('.cancelBtn').onclick=()=>disableEdit(tr);
     tr.querySelector('.saveBtn').onclick=()=>saveRow(tr,u.userId);
+    tr.querySelector('.pwBtn').onclick=()=>showResetPwModal(u.userId);
     body.appendChild(tr);
   });
 }
@@ -742,8 +745,21 @@ function addNewUser(){
   const p1=document.getElementById('newPw1').value;
   const p2=document.getElementById('newPw2').value;
   if(p1!==p2){alert('Passwords do not match');return;}
-  if(!/^(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/.test(p1)){alert('Weak password');return;}
   google.script.run.withSuccessHandler(()=>{document.getElementById('newUserModal').classList.add('hidden');loadUsers();}).withFailureHandler(err=>alert(err.message)).addNewUser({userId:uid,password:p1,role:r});
+}
+
+function showResetPwModal(uid){
+  resetUid=uid;
+  document.getElementById('resetPw1').value='';
+  document.getElementById('resetPw2').value='';
+  document.getElementById('resetPwModal').classList.remove('hidden');
+}
+
+function resetPassword(){
+  const p1=document.getElementById('resetPw1').value;
+  const p2=document.getElementById('resetPw2').value;
+  if(p1!==p2){alert('Passwords do not match');return;}
+  google.script.run.withSuccessHandler(()=>{document.getElementById('resetPwModal').classList.add('hidden');}).withFailureHandler(err=>alert(err.message)).updateUserPassword(resetUid,p1);
 }
 
 // ---- Simple Scheduling -----
@@ -864,6 +880,17 @@ document.addEventListener('DOMContentLoaded',init);
       <div class="flex justify-between">
         <button class="primary" onclick="addNewUser()">Save</button>
         <button onclick="document.getElementById('newUserModal').classList.add('hidden')">Cancel</button>
+      </div>
+    </div>
+  </div>
+  <div id="resetPwModal" class="modal hidden">
+    <div class="bg-white rounded-xl p-6 w-80 space-y-4">
+      <h4 class="text-lg font-semibold text-center">Reset Password</h4>
+      <input id="resetPw1" type="password" class="w-full border px-2 py-1" placeholder="New Password">
+      <input id="resetPw2" type="password" class="w-full border px-2 py-1" placeholder="Confirm Password">
+      <div class="flex justify-between">
+        <button class="primary" onclick="resetPassword()">Save</button>
+        <button onclick="document.getElementById('resetPwModal').classList.add('hidden')">Cancel</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow any password length/characters when adding a user
- support resetting a user's password from the developer console
- document password reset ability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68810a9a114c83228db56705ec747cbb