### PR TITLE
Fix auto sign-in behavior

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -125,19 +125,17 @@ function logout() {
   CacheService.getUserCache().remove(CACHE_KEY);
 }
 
-/** Get current session user */
+/**
+ * Get current session user. This simply returns any cached session. Developer
+ * accounts are no longer auto-signed in here; that logic now lives inside
+ * `isAuthorizedDev()` when the Dev panel is opened.
+ */
 function getSession() {
   const cache = CacheService.getUserCache();
   const data = cache.get(CACHE_KEY);
   if (data) return JSON.parse(data);
-  const email = Session.getActiveUser().getEmail();
-  // Only allow auto sign-in for whitelisted developer accounts
-  if (email && DEV_USERS.indexOf(email) !== -1) {
-    const user = {id: email, userId: email, name: email,
-                  role: 'DEV', managerId: '', lang: 'en'};
-    cache.put(CACHE_KEY, JSON.stringify(user), SESSION_DURATION);
-    return user;
-  }
+  // Do not auto-sign in here. Authorization should only occur via explicit
+  // developer actions (e.g. opening the Dev panel).
   return null;
 }
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This project contains a simple Google Apps Script web application used to collec
   `skhun@dublincleaners.com` and `ss.sku@protonmail.com` are allowed to access
   it. Authorized developers can create new users from the panel with passwords of
   any complexity. They can also reset an existing user's password from the dev
-  panel. All passwords are hashed before being stored. Developer accounts
-  automatically sign in via the Chrome browser's OAuth session and do not
-  require a password. When the page loads and the OAuth email matches one of the
-  developer accounts, the dev panel opens automatically with no password prompt.
+  panel. All passwords are hashed before being stored. Developer accounts do not
+  require a password. Instead, clicking the Dev button uses the Chrome browser's
+  OAuth session to authenticate. Only the whitelisted developer accounts can
+  open the dev panel this way.
 
 The project is intentionally lightweight and open. Feel free to modify or extend it as needed.


### PR DESCRIPTION
## Summary
- stop automatically signing in developer accounts in `getSession`
- document new dev sign-in flow in README

## Testing
- `node --check /tmp/test.js`

------
https://chatgpt.com/codex/tasks/task_e_68813e4437d083228cda7c407d37f3a2