### PR TITLE
Fix serveIndex_ output to avoid missing getResponse method

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -589,12 +589,10 @@ function serveIndex_(){
     cache.put('idx',html,CACHE_TTL);
   }
   const out=HtmlService.createHtmlOutput(html);
-  const resp=out.getResponse();
-  resp.setHeader('Cache-Control','max-age=3600, public');
-  resp.setHeader('X-Content-Type-Options','nosniff');
-  resp.setHeader('X-Frame-Options','SAMEORIGIN');
-  resp.setHeader('Content-Security-Policy',"default-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com https://fonts.gstatic.com");
-  return resp;
+  // Apps Script's HtmlOutput doesn't expose a raw HTTP response object, so
+  // custom headers such as Cache-Control can't be set directly. Simply return
+  // the HtmlOutput for rendering.
+  return out;
 }
 
 /** --- Scheduling Helpers & API Endpoints -------------------------------- */


### PR DESCRIPTION
## Summary
- remove reference to `HtmlOutput.getResponse()` which doesn't exist in Apps Script
- return the `HtmlOutput` object directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688186bf06948322b22a2e02ed5429cf