### PR TITLE
Handle missing FullCalendar plugins in calendar init

### DIFF
--- a/index.html
+++ b/index.html
@@ -1523,8 +1523,13 @@ function initCalendar(){
   }
   const initialView=window.innerWidth<768?'timeGridDay':'timeGridWeek';
   if(!calendar){
+    const plugins=[fc.timeGridPlugin,fc.dayGridPlugin,fc.listPlugin,fc.interactionPlugin].filter(Boolean);
+    if(plugins.length===0){
+      console.error('FullCalendar plugins failed to load');
+      return;
+    }
     calendar=new fc.Calendar(el,{
-      plugins:[fc.timeGridPlugin,fc.dayGridPlugin,fc.listPlugin,fc.interactionPlugin],
+      plugins:plugins,
       initialView:initialView,
       locale:lang==='es'?'es':'en',
       headerToolbar:{start:'prev,next today',center:'title',end:'timeGridDay,timeGridWeek,dayGridMonth'},


### PR DESCRIPTION
## Summary
- filter undefined FullCalendar plugin references when initializing the schedule calendar
- add a defensive log/exit to avoid runtime failures if the FullCalendar bundle fails to expose plugins

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dfea59d91c832e827b170296e78375