### PR TITLE
Fix calendar plugin loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 <link href="https://fonts.googleapis.com/css2?family=Dancing+Script&amp;display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <script src="https://cdn.tailwindcss.com"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css">
-<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css">
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
 <style>
 :root{
   --emerald-50:#f0f8f3;


### PR DESCRIPTION
## Summary
- explain that the previous FullCalendar 6 global bundle did not ship the timeGrid/dayGrid plugins that the app expects
- switch to the widely used FullCalendar 5 main bundle that includes the required plugins so the calendar renders reliably

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dfeb351558832e90063cf92155a398