### PR TITLE
Darken available slot text in calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,7 +585,7 @@ button.secondary:hover{background:var(--emerald-50);box-shadow:none;}
 .slot-save:hover{box-shadow:0 10px 20px rgba(10,92,48,0.16);}
 #calendar{width:100%;}
 .fc .booking-event{border:none !important;box-shadow:none !important;font-weight:600;}
-.fc .booking-open{background:#dcfce7 !important;color:#166534 !important;}
+.fc .booking-open{background:#dcfce7 !important;color:var(--emerald-800) !important;}
 .fc .booking-booked{background:#fee2e2 !important;color:#b91c1c !important;}
 .fc .booking-mine{background:#dbeafe !important;color:#1d4ed8 !important;}
 .fc .booking-past{opacity:0.5;}


### PR DESCRIPTION
## Summary
- darken available slot text in the FullCalendar view by using the existing emerald palette for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dff873217c832e9c9bc5758ca9aba0